### PR TITLE
Use direct server ID retrieval for DoneEvent

### DIFF
--- a/DoneEvent.java
+++ b/DoneEvent.java
@@ -15,6 +15,10 @@ class DoneEvent extends Event {
         return 1;
     }
 
+    int getServerID() {
+        return this.serverID;
+    }
+
     public String toString() {
         String serverStr = shop.accessParticularServer(serverID).isHuman() 
             ? String.valueOf(serverID) : String.format("self-check %d", serverID);

--- a/Simulator.java
+++ b/Simulator.java
@@ -73,14 +73,11 @@ class Simulator {
             Event theNextEvent = pairES.first();
             Shop updatedShop = pairES.second();
 
-            if (event.toString().contains("done")) {
-                String eventStr = event.toString();
-                int length = eventStr.length();
-                int serverID = Character.getNumericValue(eventStr.charAt(length - 1));
-
-                if (serverID > numOfServers) {
-                    // if the server isn't human
-                    serverID = numOfServers + 1;
+            if (event instanceof DoneEvent) {
+                int serverID = ((DoneEvent) event).getServerID();
+                Server eventServer = shop.accessParticularServer(serverID);
+                if (!eventServer.isHuman()) {
+                    serverID = eventServer.getID();
                 }
 
 


### PR DESCRIPTION
## Summary
- add `getServerID()` in `DoneEvent`
- check for `DoneEvent` in `Simulator.simulate`
- avoid parsing server ID from strings

## Testing
- `javac *.java`
- `printf '1 0 1 1 0\n0.0 1.0\n' | java Main`
- `printf '0 2 1 2 0\n0.0 1.0 0.1 1.0\n' | java Main`


------
https://chatgpt.com/codex/tasks/task_e_683ff1ea746c83298d04630ca2df7def