### PR TITLE
Add test for DoneEvent multi-digit IDs

### DIFF
--- a/DoneEvent.java
+++ b/DoneEvent.java
@@ -15,6 +15,10 @@ class DoneEvent extends Event {
         return 1;
     }
 
+    int getServerID() {
+        return this.serverID;
+    }
+
     public String toString() {
         String serverStr = shop.accessParticularServer(serverID).isHuman() 
             ? String.valueOf(serverID) : String.format("self-check %d", serverID);

--- a/Simulator.java
+++ b/Simulator.java
@@ -73,11 +73,8 @@ class Simulator {
             Event theNextEvent = pairES.first();
             Shop updatedShop = pairES.second();
 
-            if (event.toString().contains("done")) {
-                String eventStr = event.toString();
-                int length = eventStr.length();
-                int serverID = Character.getNumericValue(eventStr.charAt(length - 1));
-
+            if (event instanceof DoneEvent) {
+                int serverID = ((DoneEvent) event).getServerID();
                 if (serverID > numOfServers) {
                     // if the server isn't human
                     serverID = numOfServers + 1;

--- a/test/SimulatorTest.java
+++ b/test/SimulatorTest.java
@@ -1,0 +1,29 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+class SimulatorTest {
+    @Test
+    void testMultiDigitServerId() {
+        ImList<Pair<Double,Supplier<Double>>> input = new ImList<>();
+        for (int i = 0; i < 10; i++) {
+            input = input.add(new Pair<>(0.0, () -> 1.0));
+        }
+        Simulator sim = new Simulator(10, 0, 1, input, () -> 0.0);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        PrintStream old = System.out;
+        System.setOut(ps);
+        try {
+            sim.simulate();
+        } finally {
+            System.setOut(old);
+        }
+        String output = baos.toString();
+        assertTrue(output.contains("10 done serving"));
+    }
+}


### PR DESCRIPTION
## Summary
- add getter for server ID in `DoneEvent`
- update `Simulator` to use new getter when handling `DoneEvent`
- create `SimulatorTest` verifying server ID 10 is handled

## Testing
- `javac *.java`
- `javac *.java test/SimulatorTest.java` *(fails: package org.junit.jupiter.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_683ff1f3b9b48329b5cfc4c61610eec7