### PR TITLE
Add Spring Boot skeleton with /simulate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,21 @@ Next steps / things to explore
 This overview should help you navigate the repository, understand how the event-driven simulation is structured, and offer ideas for future learning and development.
 
 
+
+Spring Boot REST API
+--------------------
+A simple Spring Boot server is included under `src/main/java/com/example/simserver`.
+It exposes a `/simulate` endpoint that runs the simulator with default
+parameters and returns the formatted statistics string.
+
+Build the project with Gradle and run the application:
+
+```
+./gradlew bootRun
+```
+
+The endpoint can be tested locally using `curl`:
+
+```
+curl 'http://localhost:8080/simulate'
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.4'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '21'
+
+def junitVersion = '5.10.2'
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.postgresql:postgresql'
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
+}
+
+test {
+    useJUnitPlatform()
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'discrete-event-simulator'

--- a/src/main/java/com/example/simserver/SimulatorApplication.java
+++ b/src/main/java/com/example/simserver/SimulatorApplication.java
@@ -1,0 +1,11 @@
+package com.example.simserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SimulatorApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SimulatorApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/simserver/SimulatorController.java
+++ b/src/main/java/com/example/simserver/SimulatorController.java
@@ -1,0 +1,29 @@
+package com.example.simserver;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import simulator.Simulator;
+import simulator.ImList;
+import simulator.Pair;
+
+import java.util.function.Supplier;
+
+@RestController
+public class SimulatorController {
+
+    @GetMapping("/simulate")
+    public String simulate(@RequestParam(defaultValue = "1") int servers,
+                           @RequestParam(defaultValue = "0") int selfChecks,
+                           @RequestParam(defaultValue = "1") int qmax,
+                           @RequestParam(defaultValue = "1") int customers) {
+
+        ImList<Pair<Double, Supplier<Double>>> inputTimes = new ImList<>();
+        for (int i = 0; i < customers; i++) {
+            inputTimes = inputTimes.add(new Pair<>((double) i, () -> 1.0));
+        }
+        Simulator sim = new Simulator(servers, selfChecks, qmax, inputTimes, () -> 0.0);
+        return sim.simulate();
+    }
+}

--- a/src/main/java/simulator/ArriveEvent.java
+++ b/src/main/java/simulator/ArriveEvent.java
@@ -1,3 +1,4 @@
+package simulator;
 class ArriveEvent extends Event {
     private static final int ARRIVE_PRIO = 4;
 

--- a/src/main/java/simulator/BackFromRestEvent.java
+++ b/src/main/java/simulator/BackFromRestEvent.java
@@ -1,3 +1,4 @@
+package simulator;
 class BackFromRestEvent extends Event {
     private final int serverID;
 

--- a/src/main/java/simulator/Counter.java
+++ b/src/main/java/simulator/Counter.java
@@ -1,3 +1,4 @@
+package simulator;
 class Counter {
     private final int name;
     private final double occupiedUntil;

--- a/src/main/java/simulator/Customer.java
+++ b/src/main/java/simulator/Customer.java
@@ -1,3 +1,4 @@
+package simulator;
 class Customer {
     private final int id;
     private final double arrivalTime;

--- a/src/main/java/simulator/CustomerComparator.java
+++ b/src/main/java/simulator/CustomerComparator.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.Comparator;
 
 class CustomerComparator implements Comparator<Customer> {

--- a/src/main/java/simulator/DoneEvent.java
+++ b/src/main/java/simulator/DoneEvent.java
@@ -1,3 +1,4 @@
+package simulator;
 class DoneEvent extends Event {
     private final int serverID;
 

--- a/src/main/java/simulator/Event.java
+++ b/src/main/java/simulator/Event.java
@@ -1,3 +1,4 @@
+package simulator;
 abstract class Event {
     protected final Customer customer;
     protected final double occurTime;

--- a/src/main/java/simulator/EventComparator.java
+++ b/src/main/java/simulator/EventComparator.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.Comparator;
 
 class EventComparator implements Comparator<Event> {

--- a/src/main/java/simulator/ImList.java
+++ b/src/main/java/simulator/ImList.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/src/main/java/simulator/Lazy.java
+++ b/src/main/java/simulator/Lazy.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.function.Supplier;
 import java.util.NoSuchElementException;
 import java.util.Optional;

--- a/src/main/java/simulator/LeaveEvent.java
+++ b/src/main/java/simulator/LeaveEvent.java
@@ -1,3 +1,4 @@
+package simulator;
 class LeaveEvent extends Event {
 
     LeaveEvent(Customer customer, double leavingTime, Shop shop) {

--- a/src/main/java/simulator/Main.java
+++ b/src/main/java/simulator/Main.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.Scanner;
 import java.util.function.Supplier;
 import java.util.Random;

--- a/src/main/java/simulator/PQ.java
+++ b/src/main/java/simulator/PQ.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.Comparator;
 import java.util.PriorityQueue;
 

--- a/src/main/java/simulator/Pair.java
+++ b/src/main/java/simulator/Pair.java
@@ -1,3 +1,4 @@
+package simulator;
 /**
  * This utility class stores two items together in a pair.
  * It could be used, for instance, to faciliate returning of

--- a/src/main/java/simulator/SelfCheckServer.java
+++ b/src/main/java/simulator/SelfCheckServer.java
@@ -1,3 +1,4 @@
+package simulator;
 class SelfCheckServer extends Server {
     private final int numOfSelfChecks;
     private final ImList<Counter> counters;

--- a/src/main/java/simulator/ServeEvent.java
+++ b/src/main/java/simulator/ServeEvent.java
@@ -1,3 +1,4 @@
+package simulator;
 class ServeEvent extends Event {
     private final int serverID;
     private final boolean prevWasDone;

--- a/src/main/java/simulator/Server.java
+++ b/src/main/java/simulator/Server.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.function.Supplier;
 
 class Server {

--- a/src/main/java/simulator/ServerQueue.java
+++ b/src/main/java/simulator/ServerQueue.java
@@ -1,3 +1,4 @@
+package simulator;
 class ServerQueue {
     // This ServerQueue is based on Immutable PQ instead of normal Queue
     // it is theoretically achieved by having the customer arrivalTime as the priority metric

--- a/src/main/java/simulator/Shop.java
+++ b/src/main/java/simulator/Shop.java
@@ -1,3 +1,4 @@
+package simulator;
 class Shop {
     private final ImList<Server> servers;
     private final Statistics stats;

--- a/src/main/java/simulator/Simulator.java
+++ b/src/main/java/simulator/Simulator.java
@@ -1,3 +1,4 @@
+package simulator;
 import java.util.function.Supplier;
 
 class Simulator {

--- a/src/main/java/simulator/Statistics.java
+++ b/src/main/java/simulator/Statistics.java
@@ -1,3 +1,4 @@
+package simulator;
 class Statistics {
     // This class deals with the statistics of the simulation
     private final double totalWaitTime;

--- a/src/main/java/simulator/WaitEvent.java
+++ b/src/main/java/simulator/WaitEvent.java
@@ -1,3 +1,4 @@
+package simulator;
 class WaitEvent extends Event {
     private final Server server;
     private static final int WAIT_PRIO = 5;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/simdb
+spring.datasource.username=simuser
+spring.datasource.password=simpass
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/example/simserver/SimulatorControllerTest.java
+++ b/src/test/java/com/example/simserver/SimulatorControllerTest.java
@@ -1,0 +1,23 @@
+package com.example.simserver;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SimulatorControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void simulateEndpointReturnsOk() throws Exception {
+        mockMvc.perform(get("/simulate"))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- reorganize Java source into packages under `src/main/java/simulator`
- introduce Gradle build with Spring Boot and JPA dependencies
- add `SimulatorApplication` and `SimulatorController` REST endpoint
- provide test stub for the controller
- document how to run the Spring Boot app

## Testing
- `gradle build -x test` *(fails: Plugin not found)*
- `gradle test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff4dc79048329ba17dc1e32a7c44b