### PR TITLE
Add PostgreSQL REST API

### DIFF
--- a/src/main/java/com/example/simserver/SimulationResult.java
+++ b/src/main/java/com/example/simserver/SimulationResult.java
@@ -1,0 +1,54 @@
+package com.example.simserver;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class SimulationResult {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int servers;
+    private int selfChecks;
+    private int qmax;
+    private int customers;
+    private String result;
+
+    public SimulationResult() {
+    }
+
+    public SimulationResult(int servers, int selfChecks, int qmax, int customers, String result) {
+        this.servers = servers;
+        this.selfChecks = selfChecks;
+        this.qmax = qmax;
+        this.customers = customers;
+        this.result = result;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getServers() {
+        return servers;
+    }
+
+    public int getSelfChecks() {
+        return selfChecks;
+    }
+
+    public int getQmax() {
+        return qmax;
+    }
+
+    public int getCustomers() {
+        return customers;
+    }
+
+    public String getResult() {
+        return result;
+    }
+}

--- a/src/main/java/com/example/simserver/SimulationResultRepository.java
+++ b/src/main/java/com/example/simserver/SimulationResultRepository.java
@@ -1,0 +1,6 @@
+package com.example.simserver;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SimulationResultRepository extends JpaRepository<SimulationResult, Long> {
+}

--- a/src/main/java/com/example/simserver/SimulatorController.java
+++ b/src/main/java/com/example/simserver/SimulatorController.java
@@ -1,6 +1,9 @@
 package com.example.simserver;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,6 +16,13 @@ import java.util.function.Supplier;
 @RestController
 public class SimulatorController {
 
+    private final SimulationResultRepository repository;
+
+    @Autowired
+    public SimulatorController(SimulationResultRepository repository) {
+        this.repository = repository;
+    }
+
     @GetMapping("/simulate")
     public String simulate(@RequestParam(defaultValue = "1") int servers,
                            @RequestParam(defaultValue = "0") int selfChecks,
@@ -24,6 +34,18 @@ public class SimulatorController {
             inputTimes = inputTimes.add(new Pair<>((double) i, () -> 1.0));
         }
         Simulator sim = new Simulator(servers, selfChecks, qmax, inputTimes, () -> 0.0);
-        return sim.simulate();
+        String result = sim.simulate();
+        repository.save(new SimulationResult(servers, selfChecks, qmax, customers, result));
+        return result;
+    }
+
+    @GetMapping("/simulations")
+    public java.util.List<SimulationResult> allResults() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/simulations/{id}")
+    public SimulationResult getResult(@PathVariable Long id) {
+        return repository.findById(id).orElse(null);
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- create `SimulationResult` entity and JPA repository
- persist results in `SimulatorController`
- expose `/simulations` REST endpoints
- use an in-memory H2 database for tests

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff92f3ab48329ad8ce53b045f8c57